### PR TITLE
Introduce cargo feature to make dependency on `reqwest` optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rust:
 
 script:
   - cargo test
+  - cargo test --no-default-features
 
 matrix:
   allow_failures:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Read GTFS (public transit timetables) files"
 name = "gtfs-structures"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Tristram Gräbener <tristramg@gmail.com>"]
 repository = "https://github.com/Tristramg/gtfs-structure"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,15 +6,19 @@ authors = ["Tristram Gräbener <tristramg@gmail.com>"]
 repository = "https://github.com/Tristramg/gtfs-structure"
 license = "MIT"
 
+[features]
+default = ["read-url"]
+read-url = ["reqwest"]
+
 [dependencies]
 csv = "1.0.0-beta.5"
 derivative = "1.0.0"
 serde = "1.0"
 serde_derive = "1.0"
 chrono = "0.4"
-regex = "0.2"
 itertools = "0.7.2"
 failure = "0.1.1"
 failure_derive = "0.1.1"
 zip = "0.3.1"
-reqwest = "0.8.5"
+
+reqwest = { version = "0.8.5", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,12 +6,13 @@ extern crate derivative;
 extern crate failure;
 #[macro_use]
 extern crate failure_derive;
-extern crate regex;
-extern crate reqwest;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate zip;
+
+#[cfg(feature = "read-url")]
+extern crate reqwest;
 
 use chrono::prelude::*;
 use chrono::Duration;
@@ -19,9 +20,11 @@ use failure::Error;
 use serde::de::{self, Deserialize, Deserializer};
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
-use std::io::Read;
 use std::path::Path;
 use std::rc::Rc;
+
+#[cfg(feature = "read-url")]
+use std::io::Read;
 
 #[derive(Fail, Debug)]
 #[fail(display = "The id {} is not known", id)]
@@ -316,6 +319,7 @@ impl Gtfs {
         Gtfs::from_reader(reader)
     }
 
+    #[cfg(feature = "read-url")]
     pub fn from_url(url: &str) -> Result<Gtfs, Error> {
         let mut res = reqwest::get(url)?;
         let mut body = Vec::new();


### PR DESCRIPTION
The `reqwest` crate pulls in a lot of dependencies that might be otherwise irrelevant for a user of `gtfs-structure`. This pull request makes the `from_url` method and the dependency on `reqwest` optional by introducing a new cargo feature `"read-url"`.

This feature is enabled by default, so this is not a breaking change: by default, nothing changes for downstream users.

Local building can be done by one of these options:

    # As before:
    $ cargo build
    # Opting out of the default features, i.e., without method `from_url`:
    $ cargo build --no-default-features
    # Explicit, but equivalend to `cargo build`:
    $ cargo build --no-default-features --features "read-url"

I also removed the dependency on the `regex` crate, since that doesn't seem to be in use anyway. It's probably not good form to do this in one pull request, but the removal fits with the idea of "removing unnecessary dependencies".